### PR TITLE
feat: allow the color to be parsed from &str

### DIFF
--- a/common/src/color.rs
+++ b/common/src/color.rs
@@ -36,9 +36,24 @@ impl fmt::Display for Color {
     }
 }
 
+impl std::str::FromStr for Color {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "black" => Ok(Color::Black),
+            "white" => Ok(Color::White),
+            "b" => Ok(Color::Black),
+            "w" => Ok(Color::White),
+            _ => Err(format!("Unable to parse '{}' into a color", s)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn will_create_the_default_color() {
@@ -58,5 +73,14 @@ mod tests {
     fn formats_it_to_the_correct_word() {
         assert_eq!(format!("{}", Color::Black), "black");
         assert_eq!(format!("{}", Color::White), "white");
+    }
+
+    #[test]
+    fn from_str() {
+        assert_eq!(Color::from_str("w"), Ok(Color::White));
+        assert_eq!(Color::from_str("white"), Ok(Color::White));
+
+        assert_eq!(Color::from_str("b"), Ok(Color::Black));
+        assert_eq!(Color::from_str("black"), Ok(Color::Black));
     }
 }

--- a/common/src/fen.rs
+++ b/common/src/fen.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::Color;
 use crate::Piece;
 use crate::Square;
@@ -86,16 +88,9 @@ impl Fen {
         }
 
         let color = parts.next();
-        let turn = if color == Some("w") {
-            Color::White
-        } else if color == Some("b") {
-            Color::Black
-        } else if let Some(c) = color {
-            return Err(format!("Unknown color '{c}' it must be one of (b, w)"));
-        } else {
-            // This needs to be here to satisfy rust however in reality this will be picked up by
-            // the six parts check.
-            return Err(format!("Unable to parse color"));
+        let turn = match color {
+            Some(c) => Color::from_str(c)?,
+            None => return Err("Unable to parse color".to_string()),
         };
 
         let mut fen = Fen {
@@ -193,10 +188,7 @@ mod tests {
     fn invalid_color() {
         let fen_string = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR x KQkq - 0 1";
         let message = Fen::from_str(fen_string).err().unwrap();
-        assert_eq!(
-            message,
-            String::from("Unknown color 'x' it must be one of (b, w)")
-        );
+        assert_eq!(message, String::from("Unable to parse 'x' into a color"));
     }
 
     macro_rules! assert_position {


### PR DESCRIPTION
Summary:

Now when you want to parse a color you can use the `from_str` trait.

```rs
let c = Color::from_str("w");
```

This will allow much cleaner syntax when trying to parse input into a color.

Test Plan:

Unit tests in CI